### PR TITLE
fix: Use correct property name `shaclPath`

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Validate data streams using SHACL.
 
 Validate an incoming data stream using SHACL. If the incoming data is valid, it is sent unchanged into the outgoing stream. Otherwise, the SHACL validation report is sent into an optional `report` channel for further investigation.
 
-- `path`: a local file path which points to a SHACL definition.
+- `shaclPath`: a local file path which points to a SHACL definition.
 - `incoming`: channel which is used as the data source.
 - `outgoing`: channel into which valid data is written.
 - `report`: an optional channel into which the SHACL reports of invalid input data is written. (default: `null`)

--- a/processors.ttl
+++ b/processors.ttl
@@ -23,7 +23,7 @@ js:Validate a js:JsProcess;
     sh:property [
         sh:datatype xsd:string;
         sh:path js:shaclPath;
-        sh:name "path";
+        sh:name "shaclPath";
         sh:maxCount 1;
         sh:minCount 1;
     ], [

--- a/tests/processors.test.ts
+++ b/tests/processors.test.ts
@@ -53,9 +53,9 @@ describe("processor", () => {
         expect(args.length).toBe(1);
         expect(args[0].length).toBe(1);
 
-        const [{ path, incoming, outgoing, report, validationIsFatal }] =
+        const [{ shaclPath, incoming, outgoing, report, validationIsFatal }] =
             args[0];
-        expect(path).toBe("/tmp/path.ttl");
+        expect(shaclPath).toBe("/tmp/path.ttl");
         expect(incoming.ty.id).toBe("https://w3id.org/conn/js#JsReaderChannel");
         expect(outgoing.ty.id).toBe("https://w3id.org/conn/js#JsWriterChannel");
         expect(report.ty.id).toBe("https://w3id.org/conn/js#JsWriterChannel");


### PR DESCRIPTION
The `sh:name` value is being used as the property name in the `args` variable here:
https://github.com/rdf-connect/shacl-processor-ts/blob/9e02fdf6d7fa2f5e950d0aa2da708b35e3ede1c0/src/index.ts#L20

Having `path` configured instead of `shaclPath` as value for `sh:name` resulted in the `shaclPath` value above being undefined at runtime. This PR fixes this.